### PR TITLE
Aligning the implementation of 'packed' fmt with current specification as of

### DIFF
--- a/src/WebAuthn.hs
+++ b/src/WebAuthn.hs
@@ -158,7 +158,7 @@ registerCredential opts cs challenge (RelyingParty rpOrigin rpId _ _) tbi verifi
   -- TODO: extensions here
   case (attStmt attestationObject) of
     AF_FIDO_U2F s -> hoistEither $ U2F.verify s ad clientDataHash
-    AF_Packed s -> hoistEither $ Packed.verify s mAdPubKey (authData attestationObject) clientDataHash
+    AF_Packed s -> hoistEither $ Packed.verify s mAdPubKey ad (authData attestationObject) clientDataHash
     AF_TPM s -> hoistEither $ TPM.verify s ad (authData attestationObject) clientDataHash
     AF_AndroidSafetyNet s -> Android.verify cs s (authData attestationObject) clientDataHash
     AF_None -> pure ()

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -82,5 +82,5 @@ verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
         decodeAAGUID bs = do
             asn1 <- either (const . Left $ MalformedX509Certificate "AAGUID decoding failed") return . decodeASN1 DER $ fromStrict bs
             case asn1 of
-              [(OctetString s)] -> Right s
+              [OctetString s] -> Right s
               _ -> Left $ MalformedX509Certificate "AAGUIID in wrong format - should be OctetString"

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module WebAuthn.Packed where
 
+import Control.Monad (when)
 import Crypto.Hash
 import Data.ByteString (ByteString)
 import qualified Data.ByteArray as BA
@@ -11,19 +12,20 @@ import qualified Data.Map as Map
 import WebAuthn.Signature
 import WebAuthn.Types
 
-data Stmt = Stmt Int ByteString (Maybe (X509.SignedExact X509.Certificate))
+data Stmt = Stmt PubKeyCredAlg ByteString (Maybe (X509.SignedExact X509.Certificate))
   deriving Show
 
 decode :: CBOR.Term -> CBOR.Decoder s Stmt
 decode (CBOR.TMap xs) = do
   let m = Map.fromList xs
   CBOR.TInt algc <- Map.lookup (CBOR.TString "alg") m ??? "alg"
+  algo <- maybe (fail $ "Packed.decode: alg not supported " <> show algc) return $ pubKeyCredAlgFromInt algc
   CBOR.TBytes sig <- Map.lookup (CBOR.TString "sig") m ??? "sig"
   cert <- case Map.lookup (CBOR.TString "x5c") m of
     Just (CBOR.TList (CBOR.TBytes certBS : _)) ->
       either fail (pure . Just) $ X509.decodeSignedCertificate certBS
     _ -> pure Nothing
-  return $ Stmt algc sig cert
+  return $ Stmt algo sig cert
   where
     Nothing ??? e = fail e
     Just a ??? _ = pure a
@@ -34,7 +36,7 @@ verify :: Stmt
   -> ByteString
   -> Digest SHA256
   -> Either VerificationFailure ()
-verify (Stmt _ sig cert) mAdPubKey adRaw clientDataHash = do
+verify (Stmt algo sig cert) mAdPubKey adRaw clientDataHash = do
   let dat = adRaw <> BA.convert clientDataHash
   case cert of
     Just x509 -> do
@@ -42,4 +44,5 @@ verify (Stmt _ sig cert) mAdPubKey adRaw clientDataHash = do
       verifyX509Sig (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pub dat sig "Packed"
     Nothing -> do
       adPubKey <- maybe (Left MalformedAuthenticatorData) return mAdPubKey
+      when (not $ hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
       verifySig adPubKey sig dat

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -7,7 +7,7 @@ import Data.ASN1.Encoding (decodeASN1)
 import Data.Maybe (isJust)
 import qualified Data.ASN1.OID as OID (OID, getObjectID)
 import Data.List (find)
-import Control.Monad (when)
+import Control.Monad (unless)
 import Crypto.Hash
 import qualified Data.ByteString as BS
 import qualified Data.ByteArray as BA
@@ -53,7 +53,7 @@ verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
         certMeetsCriteria x509Cert
     Nothing -> do
       adPubKey <- maybe (Left MalformedAuthenticatorData) return mAdPubKey
-      when (not $ hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
+      unless (hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
       verifySig adPubKey sig dat
     where
         certMeetsCriteria :: X509.Certificate -> Either VerificationFailure ()
@@ -63,8 +63,8 @@ verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
                 dnElements = X509.getDistinguishedElements $ X509.certSubjectDN c
             adAAGUID <- maybe (Left $ MalformedX509Certificate "No AAGUID provided in attested credential data") (return . unAAGUID . aaguid) $ attestedCredentialData ad
             certAAGUID <- maybe (Left $ MalformedX509Certificate "No AAGUID present in x509 extensions") (decodeAAGUID . X509.extRawContent) mX509Ext
-            when (certAAGUID /= adAAGUID) . Left . MalformedX509Certificate $ "AAGUID in attested credential data doesn't match the one in x509 extensions"
-            when (not 
+            unless (certAAGUID == adAAGUID) . Left . MalformedX509Certificate $ "AAGUID in attested credential data doesn't match the one in x509 extensions"
+            unless ( 
                 (hasDnElement X509.DnCountry dnElements)
                 &&
                 (hasDnElement X509.DnOrganization dnElements)

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -75,7 +75,7 @@ verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
         hasDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Bool
         hasDnElement el = isJust . findDnElement el
         findDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Maybe X509.ASN1CharacterString
-        findDnElement dnElementName = fmap snd . find ((==) (OID.getObjectID dnElementName) . fst)
+        findDnElement dnElementName = lookup (OID.getObjectID dnElementName)
         findProperExtension :: OID.OID -> [X509.ExtensionRaw] -> Maybe X509.ExtensionRaw
         findProperExtension extensionOID = find ((==) extensionOID . X509.extRawOID)
         decodeAAGUID :: BS.ByteString -> Either VerificationFailure BS.ByteString

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -1,6 +1,12 @@
-
 module WebAuthn.Packed where
 
+import Data.ByteString.Lazy (fromStrict)
+import Data.ASN1.BinaryEncoding (DER(..))
+import Data.ASN1.Prim (ASN1(..))
+import Data.ASN1.Encoding (decodeASN1)
+import Data.ByteString.Char8 (unpack)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text, pack)
 import Data.Maybe (isJust)
 import qualified Data.ASN1.OID as OID (OID, getObjectID)
 import Data.List (find)
@@ -47,32 +53,40 @@ verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
         let x509Cert = X509.getCertificate x509 
             pub = X509.certPubKey x509Cert
         verifyX509Sig (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pub dat sig "Packed"
-        when (not (certMeetsCriteria x509Cert)) $ Left MalformedAuthenticatorData
+        certMeetsCriteria x509Cert
     Nothing -> do
       adPubKey <- maybe (Left MalformedAuthenticatorData) return mAdPubKey
       when (not $ hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
       verifySig adPubKey sig dat
     where
-        certMeetsCriteria :: X509.Certificate -> Bool
-        certMeetsCriteria c =
-            let 
-                maaguid = unAAGUID . aaguid <$> attestedCredentialData ad
+        certMeetsCriteria :: X509.Certificate -> Either VerificationFailure ()
+        certMeetsCriteria c = do
+            let maaguid = unAAGUID . aaguid <$> attestedCredentialData ad
                 (X509.Extensions mX509Exts) = X509.certExtensions c
                 mX509Ext = mX509Exts >>= findProperExtension [1,3,6,1,4,1,45724,1,1,4]
                 dnElements = X509.getDistinguishedElements $ X509.certSubjectDN c
-            in
-                (maybe False ((==) maaguid . Just . X509.extRawContent) mX509Ext)
-                &&
+            adAAGUID <- maybe (Left $ MalformedX509Certificate "No AAGUID provided in attested credential data") (return . unAAGUID . aaguid) $ attestedCredentialData ad
+            certAAGUID <- maybe (Left $ MalformedX509Certificate "No AAGUID present in x509 extensions") (decodeAAGUID . X509.extRawContent) mX509Ext
+            when (certAAGUID /= adAAGUID) . Left . MalformedX509Certificate $ "AAGUID in attested credential data doesn't match the one in x509 extensions"
+            when (not 
                 (hasDnElement X509.DnCountry dnElements)
                 &&
                 (hasDnElement X509.DnOrganization dnElements)
                 &&
                 (hasDnElement X509.DnCommonName dnElements)
                 &&
-                (findDnElement X509.DnOrganizationUnit dnElements == Just "Authenticator Attestation")
+                (findDnElement X509.DnOrganizationUnit dnElements == Just "Authenticator Attestation")) . Left $ MalformedX509Certificate "Certificate SubjectDN doesn't meet crtieria"
         hasDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Bool
         hasDnElement el = isJust . findDnElement el
         findDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Maybe X509.ASN1CharacterString
         findDnElement dnElementName = fmap snd . find ((==) (OID.getObjectID dnElementName) . fst)
         findProperExtension :: OID.OID -> [X509.ExtensionRaw] -> Maybe X509.ExtensionRaw
         findProperExtension extensionOID = find ((==) extensionOID . X509.extRawOID)
+        showByteString :: Maybe ByteString -> Text
+        showByteString bs = fromMaybe "" (pack . unpack <$> bs)
+        decodeAAGUID :: ByteString -> Either VerificationFailure ByteString
+        decodeAAGUID bs = do
+            asn1 <- either (const . Left $ MalformedX509Certificate "AAGUID decoding failed") return . decodeASN1 DER $ fromStrict bs
+            case asn1 of
+              [(OctetString s)] -> Right s
+              _ -> Left $ MalformedX509Certificate "AAGUIID in wrong format - should be OctetString"

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -1,6 +1,9 @@
-{-# LANGUAGE OverloadedStrings #-}
+
 module WebAuthn.Packed where
 
+import Data.Maybe (isJust)
+import qualified Data.ASN1.OID as OID (OID, getObjectID)
+import Data.List (find)
 import Control.Monad (when)
 import Crypto.Hash
 import Data.ByteString (ByteString)
@@ -33,16 +36,43 @@ decode _ = fail "Packed.decode: expected a Map"
 
 verify :: Stmt
   -> Maybe PublicKey
+  -> AuthenticatorData
   -> ByteString
   -> Digest SHA256
   -> Either VerificationFailure ()
-verify (Stmt algo sig cert) mAdPubKey adRaw clientDataHash = do
+verify (Stmt algo sig cert) mAdPubKey ad adRaw clientDataHash = do
   let dat = adRaw <> BA.convert clientDataHash
   case cert of
     Just x509 -> do
-      let pub = X509.certPubKey $ X509.getCertificate x509
-      verifyX509Sig (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pub dat sig "Packed"
+        let x509Cert = X509.getCertificate x509 
+            pub = X509.certPubKey x509Cert
+        verifyX509Sig (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pub dat sig "Packed"
+        when (not (certMeetsCriteria x509Cert)) $ Left MalformedAuthenticatorData
     Nothing -> do
       adPubKey <- maybe (Left MalformedAuthenticatorData) return mAdPubKey
       when (not $ hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
       verifySig adPubKey sig dat
+    where
+        certMeetsCriteria :: X509.Certificate -> Bool
+        certMeetsCriteria c =
+            let 
+                maaguid = unAAGUID . aaguid <$> attestedCredentialData ad
+                (X509.Extensions mX509Exts) = X509.certExtensions c
+                mX509Ext = mX509Exts >>= findProperExtension [1,3,6,1,4,1,45724,1,1,4]
+                dnElements = X509.getDistinguishedElements $ X509.certSubjectDN c
+            in
+                (maybe False ((==) maaguid . Just . X509.extRawContent) mX509Ext)
+                &&
+                (hasDnElement X509.DnCountry dnElements)
+                &&
+                (hasDnElement X509.DnOrganization dnElements)
+                &&
+                (hasDnElement X509.DnCommonName dnElements)
+                &&
+                (findDnElement X509.DnOrganizationUnit dnElements == Just "Authenticator Attestation")
+        hasDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Bool
+        hasDnElement el = isJust . findDnElement el
+        findDnElement :: X509.DnElement -> [(OID.OID, X509.ASN1CharacterString)] -> Maybe X509.ASN1CharacterString
+        findDnElement dnElementName = fmap snd . find ((==) (OID.getObjectID dnElementName) . fst)
+        findProperExtension :: OID.OID -> [X509.ExtensionRaw] -> Maybe X509.ExtensionRaw
+        findProperExtension extensionOID = find ((==) extensionOID . X509.extRawOID)

--- a/src/WebAuthn/Types.hs
+++ b/src/WebAuthn/Types.hs
@@ -37,6 +37,7 @@ module WebAuthn.Types (
   , AuthenticatorSelection (..)
   , UserVerification (..)
   , PubKeyCredAlg (..)
+  , pubKeyCredAlgFromInt
   ) where
 
 import Prelude hiding (fail)
@@ -364,6 +365,12 @@ instance ToJSON PubKeyCredAlg where
   toJSON RS256 = Number (-257)
   toJSON PS256 = Number (-37)
   
+pubKeyCredAlgFromInt :: Int -> Maybe PubKeyCredAlg
+pubKeyCredAlgFromInt = \case -7 -> Just ES256
+                             -257 -> Just RS256
+                             -37 -> Just PS256
+                             _ -> Nothing
+
 data PubKeyCredParam = PubKeyCredParam {
   tipe :: PublicKeyCredentialType
   , alg :: PubKeyCredAlg

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -76,50 +76,49 @@ decodePanic s = either error Prelude.id (A.eitherDecode (BL.fromStrict s))
 
 data TestPublicKeyCredential = TestPublicKeyCredential 
                                 {
-                                   clientDataJSON :: ByteString
-                                   , attestationObject :: ByteString
-                                   , challenge :: Challenge
-                                   , getChallenge :: Challenge
-                                   , getClientDataJSON :: ByteString
-                                   , getAuthenticatorData :: ByteString
-                                   , getSignature :: ByteString
-                               }
+                                clientDataJSON :: ByteString
+                                , attestationObject :: ByteString
+                                , challenge :: Challenge
+                                , getChallenge :: Challenge
+                                , getClientDataJSON :: ByteString
+                                , getAuthenticatorData :: ByteString
+                                , getSignature :: ByteString
+                                }
 
 
 androidPublicKeyCredential = TestPublicKeyCredential 
                              {
-                                clientDataJSON = androidClientDataJSON
-                                , attestationObject = androidAttestationObject
-                                , challenge = androidChallenge
-                                , getChallenge = androidGetChallenge
-                                , getClientDataJSON = androidGetClientDataJSON
-                                , getAuthenticatorData = androidGetAuthenticatorData
-                                , getSignature = androidGetSignature
+                             clientDataJSON = androidClientDataJSON
+                             , attestationObject = androidAttestationObject
+                             , challenge = androidChallenge
+                             , getChallenge = androidGetChallenge
+                             , getClientDataJSON = androidGetClientDataJSON
+                             , getAuthenticatorData = androidGetAuthenticatorData
+                             , getSignature = androidGetSignature
                              }
 
 packedSelfAttestedKeyCredential = TestPublicKeyCredential 
                               {
-                                  clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSkhxcVRQWF9oQkw1bHlDZE9DQzRMNTVzcm9LbXFMX0RDemlOeWx6MXF5dyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
-                                , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEYwRAIgaAVCWvaUJo0NBq_c1yr7R9jXN-G8MqqIOVhswsTX4K0CIFZul9oOTdWwDx4WAb3cgPTTjWzXSSxcjseS33OVqhgWaGF1dGhEYXRhWNUs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUVgAZ6yrc4AAjW8xgpkiwsl8fBVAwBRAft9ACeHPR6QCu6Clp5otBmdIyMGV6w1emT--vpR_JpIKPJdIkNLOjzoLqd-z_j3vKvLCB4pQAwccqPF56HKs4h8DsrEuG0mMx5jJz_9ndh1pQECAyYgASFYIFgD8QsPYGMaq49F7-JWJowfVaxeiFzJUXp2k8nvrRpUIlggyGWqdGOBLZgO61mPMEncHjTmBxFPWzqKbUlBvT1fhRg"
-                                , challenge = Challenge (BS.decodeLenient "JHqqTPX_hBL5lyCdOCC4L55sroKmqL_DCziNylz1qyw")
-                                , getChallenge = Challenge (BS.decodeLenient "VXrK0ywwsYO2k6c52md-Lg2JDOmxrkGMli_4MHJcKaM")
-                                , getClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiVlhySzB5d3dzWU8yazZjNTJtZC1MZzJKRE9teHJrR01saV80TUhKY0thTSIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0"
-                                , getAuthenticatorData = BS.decodeLenient "LNeTz6C0GMu_DqhSIoYH2el7Mz1NsKQQF3Zq9ruMdVEFYAGfAg"
-                                , getSignature = BS.decodeLenient "MEYCIQDteZqnEublzIw5AgnOzu5sd7b387GitIHbjNSXFFoFxgIhAP4IFIiyweG__D3VOBSnvneuK794RuGoUNasXhQNe0gk"
-        
-    }
+                              clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSkhxcVRQWF9oQkw1bHlDZE9DQzRMNTVzcm9LbXFMX0RDemlOeWx6MXF5dyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+                              , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEYwRAIgaAVCWvaUJo0NBq_c1yr7R9jXN-G8MqqIOVhswsTX4K0CIFZul9oOTdWwDx4WAb3cgPTTjWzXSSxcjseS33OVqhgWaGF1dGhEYXRhWNUs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUVgAZ6yrc4AAjW8xgpkiwsl8fBVAwBRAft9ACeHPR6QCu6Clp5otBmdIyMGV6w1emT--vpR_JpIKPJdIkNLOjzoLqd-z_j3vKvLCB4pQAwccqPF56HKs4h8DsrEuG0mMx5jJz_9ndh1pQECAyYgASFYIFgD8QsPYGMaq49F7-JWJowfVaxeiFzJUXp2k8nvrRpUIlggyGWqdGOBLZgO61mPMEncHjTmBxFPWzqKbUlBvT1fhRg"
+                              , challenge = Challenge (BS.decodeLenient "JHqqTPX_hBL5lyCdOCC4L55sroKmqL_DCziNylz1qyw")
+                              , getChallenge = Challenge (BS.decodeLenient "VXrK0ywwsYO2k6c52md-Lg2JDOmxrkGMli_4MHJcKaM")
+                              , getClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiVlhySzB5d3dzWU8yazZjNTJtZC1MZzJKRE9teHJrR01saV80TUhKY0thTSIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0"
+                              , getAuthenticatorData = BS.decodeLenient "LNeTz6C0GMu_DqhSIoYH2el7Mz1NsKQQF3Zq9ruMdVEFYAGfAg"
+                              , getSignature = BS.decodeLenient "MEYCIQDteZqnEublzIw5AgnOzu5sd7b387GitIHbjNSXFFoFxgIhAP4IFIiyweG__D3VOBSnvneuK794RuGoUNasXhQNe0gk"
+                              }
 
 packedSelfAttestedTest = genericCredentialTest "Packed self attested test" packedSelfAttestedKeyCredential
 
 packedNonSelfAttestedKeyCredential = TestPublicKeyCredential 
                               {
-                                  clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTU1jVUFkWkJ2STRENktNYldjZW44bTNNRElCRWVWQWxkalBwcjYzZWFJbyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
-                                , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIge9MVIqCg80CbXoD2m6Hu4J6EKztfia76dtOoAeDUejQCIQCQwLbwVYoiYsAcOf8iigzbixDBiUAYJpUCIoa-XXvuYmN4NWOBWQLBMIICvTCCAaWgAwIBAgIEGKxGwDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNDEzOTQzNDg4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeeo7LHxJcBBiIwzSP-tg5SkxcdSD8QC-hZ1rD4OXAwG1Rs3Ubs_K4-PzD4Hp7WK9Jo1MHr03s7y-kqjCrutOOqNsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCBSAwIQYLKwYBBAGC5RwBAQQEEgQQy2lIHo_3QDmT7AonKaFUqDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCXnQOX2GD4LuFdMRx5brr7Ivqn4ITZurTGG7tX8-a0wYpIN7hcPE7b5IND9Nal2bHO2orh_tSRKSFzBY5e4cvda9rAdVfGoOjTaCW6FZ5_ta2M2vgEhoz5Do8fiuoXwBa1XCp61JfIlPtx11PXm5pIS2w3bXI7mY0uHUMGvxAzta74zKXLslaLaSQibSKjWKt9h-SsXy4JGqcVefOlaQlJfXL1Tga6wcO0QTu6Xq-Uw7ZPNPnrpBrLauKDd202RlN4SP7ohL3d9bG6V5hUz_3OusNEBZUn5W3VmPj1ZnFavkMB3RkRMOa58MZAORJT4imAPzrvJ0vtv94_y71C6tZ5aGF1dGhEYXRhWMQs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUUAAAAuy2lIHo_3QDmT7AonKaFUqABAPjPqie67O5ZBLiBEWi1uF8ueqxifIu5txG8qQ82HiribGY2F99HPJ_ZTgRbEZCVySxy0Xbd-tiUzyEwmJQsiNqUBAgMmIAEhWCAiZN75DKsRFIWYKExiHA_ZpKIJGbRlL2JYE6iw9x1OGSJYILwa9HpPBuZ4S4BfT4wigrSzs_V6m47z0A1wsetLUwl1"
-                                , challenge = Challenge (BS.decodeLenient "MMcUAdZBvI4D6KMbWcen8m3MDIBEeVAldjPpr63eaIo")
-                                , getChallenge = Challenge (BS.decodeLenient "Yb5eG9OA4jPLlrkGIMhedXD76XHqJhddTAdeHXHBRl8")
-                                , getClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiWWI1ZUc5T0E0alBMbHJrR0lNaGVkWEQ3NlhIcUpoZGRUQWRlSFhIQlJsOCIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
-                                , getAuthenticatorData = BS.decodeLenient "LNeTz6C0GMu_DqhSIoYH2el7Mz1NsKQQF3Zq9ruMdVEFAAAALw"
-                                , getSignature = BS.decodeLenient "MEUCIAUiSZx7SeFuqLS7nCtfEwgHM7zfhJQTx2AUf6qW0P0TAiEAh-UwgffnlRaz5cjYeGirABt2FTcgyiuLuv-NOpdJQf8"
+                              clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTU1jVUFkWkJ2STRENktNYldjZW44bTNNRElCRWVWQWxkalBwcjYzZWFJbyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+                              , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIge9MVIqCg80CbXoD2m6Hu4J6EKztfia76dtOoAeDUejQCIQCQwLbwVYoiYsAcOf8iigzbixDBiUAYJpUCIoa-XXvuYmN4NWOBWQLBMIICvTCCAaWgAwIBAgIEGKxGwDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNDEzOTQzNDg4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeeo7LHxJcBBiIwzSP-tg5SkxcdSD8QC-hZ1rD4OXAwG1Rs3Ubs_K4-PzD4Hp7WK9Jo1MHr03s7y-kqjCrutOOqNsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCBSAwIQYLKwYBBAGC5RwBAQQEEgQQy2lIHo_3QDmT7AonKaFUqDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCXnQOX2GD4LuFdMRx5brr7Ivqn4ITZurTGG7tX8-a0wYpIN7hcPE7b5IND9Nal2bHO2orh_tSRKSFzBY5e4cvda9rAdVfGoOjTaCW6FZ5_ta2M2vgEhoz5Do8fiuoXwBa1XCp61JfIlPtx11PXm5pIS2w3bXI7mY0uHUMGvxAzta74zKXLslaLaSQibSKjWKt9h-SsXy4JGqcVefOlaQlJfXL1Tga6wcO0QTu6Xq-Uw7ZPNPnrpBrLauKDd202RlN4SP7ohL3d9bG6V5hUz_3OusNEBZUn5W3VmPj1ZnFavkMB3RkRMOa58MZAORJT4imAPzrvJ0vtv94_y71C6tZ5aGF1dGhEYXRhWMQs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUUAAAAuy2lIHo_3QDmT7AonKaFUqABAPjPqie67O5ZBLiBEWi1uF8ueqxifIu5txG8qQ82HiribGY2F99HPJ_ZTgRbEZCVySxy0Xbd-tiUzyEwmJQsiNqUBAgMmIAEhWCAiZN75DKsRFIWYKExiHA_ZpKIJGbRlL2JYE6iw9x1OGSJYILwa9HpPBuZ4S4BfT4wigrSzs_V6m47z0A1wsetLUwl1"
+                              , challenge = Challenge (BS.decodeLenient "MMcUAdZBvI4D6KMbWcen8m3MDIBEeVAldjPpr63eaIo")
+                              , getChallenge = Challenge (BS.decodeLenient "Yb5eG9OA4jPLlrkGIMhedXD76XHqJhddTAdeHXHBRl8")
+                              , getClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiWWI1ZUc5T0E0alBMbHJrR0lNaGVkWEQ3NlhIcUpoZGRUQWRlSFhIQlJsOCIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+                              , getAuthenticatorData = BS.decodeLenient "LNeTz6C0GMu_DqhSIoYH2el7Mz1NsKQQF3Zq9ruMdVEFAAAALw"
+                              , getSignature = BS.decodeLenient "MEUCIAUiSZx7SeFuqLS7nCtfEwgHM7zfhJQTx2AUf6qW0P0TAiEAh-UwgffnlRaz5cjYeGirABt2FTcgyiuLuv-NOpdJQf8"
                               }
 
 packedNonSelfAttestedTest = genericCredentialTest "Packed non-self attested test" packedNonSelfAttestedKeyCredential

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -46,7 +46,8 @@ androidCredentialTest :: TestTree
 androidCredentialTest = testCaseSteps "Android Test" $ \step -> do
   step "Registeration check..."
   Just k <- readCertificateStore "test/cacert.pem"
-  eth <- registerCredential k androidChallenge defRp Nothing False androidClientDataJSON androidAttestationObject
+  let pkcco = PublicKeyCredentialCreationOptions (defaultRelyingParty (Origin "https" "webauthn.biz" Nothing)) (Base64ByteString "12343434") (User (Base64ByteString "id") Nothing Nothing) (PubKeyCredParam PublicKey ES256 :| []) Nothing Nothing Nothing Nothing (Just (PublicKeyCredentialDescriptor PublicKey (Base64ByteString "1234") (Just (BLE :| []))  :| []))
+  eth <- registerCredential pkcco k androidChallenge defRp Nothing False androidClientDataJSON androidAttestationObject
   assertBool (show eth) (isRight eth)
   let Right cdata = eth
   step "Verification check..."

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -41,6 +41,7 @@ androidTests = testGroup "WebAuthn Tests"
   [
     androidCredentialTest
     , packedSelfAttestedTest
+    , packedNonSelfAttestedTest
     , registrationTest
   ]
 
@@ -109,6 +110,19 @@ packedSelfAttestedKeyCredential = TestPublicKeyCredential
     }
 
 packedSelfAttestedTest = genericCredentialTest "Packed self attested test" packedSelfAttestedKeyCredential
+
+packedNonSelfAttestedKeyCredential = TestPublicKeyCredential 
+                              {
+                                  clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTU1jVUFkWkJ2STRENktNYldjZW44bTNNRElCRWVWQWxkalBwcjYzZWFJbyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+                                , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIge9MVIqCg80CbXoD2m6Hu4J6EKztfia76dtOoAeDUejQCIQCQwLbwVYoiYsAcOf8iigzbixDBiUAYJpUCIoa-XXvuYmN4NWOBWQLBMIICvTCCAaWgAwIBAgIEGKxGwDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNDEzOTQzNDg4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeeo7LHxJcBBiIwzSP-tg5SkxcdSD8QC-hZ1rD4OXAwG1Rs3Ubs_K4-PzD4Hp7WK9Jo1MHr03s7y-kqjCrutOOqNsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCBSAwIQYLKwYBBAGC5RwBAQQEEgQQy2lIHo_3QDmT7AonKaFUqDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCXnQOX2GD4LuFdMRx5brr7Ivqn4ITZurTGG7tX8-a0wYpIN7hcPE7b5IND9Nal2bHO2orh_tSRKSFzBY5e4cvda9rAdVfGoOjTaCW6FZ5_ta2M2vgEhoz5Do8fiuoXwBa1XCp61JfIlPtx11PXm5pIS2w3bXI7mY0uHUMGvxAzta74zKXLslaLaSQibSKjWKt9h-SsXy4JGqcVefOlaQlJfXL1Tga6wcO0QTu6Xq-Uw7ZPNPnrpBrLauKDd202RlN4SP7ohL3d9bG6V5hUz_3OusNEBZUn5W3VmPj1ZnFavkMB3RkRMOa58MZAORJT4imAPzrvJ0vtv94_y71C6tZ5aGF1dGhEYXRhWMQs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUUAAAAuy2lIHo_3QDmT7AonKaFUqABAPjPqie67O5ZBLiBEWi1uF8ueqxifIu5txG8qQ82HiribGY2F99HPJ_ZTgRbEZCVySxy0Xbd-tiUzyEwmJQsiNqUBAgMmIAEhWCAiZN75DKsRFIWYKExiHA_ZpKIJGbRlL2JYE6iw9x1OGSJYILwa9HpPBuZ4S4BfT4wigrSzs_V6m47z0A1wsetLUwl1"
+                                , challenge = Challenge (BS.decodeLenient "MMcUAdZBvI4D6KMbWcen8m3MDIBEeVAldjPpr63eaIo")
+                                , getChallenge = Challenge (BS.decodeLenient "Yb5eG9OA4jPLlrkGIMhedXD76XHqJhddTAdeHXHBRl8")
+                                , getClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiWWI1ZUc5T0E0alBMbHJrR0lNaGVkWEQ3NlhIcUpoZGRUQWRlSFhIQlJsOCIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+                                , getAuthenticatorData = BS.decodeLenient "LNeTz6C0GMu_DqhSIoYH2el7Mz1NsKQQF3Zq9ruMdVEFAAAALw"
+                                , getSignature = BS.decodeLenient "MEUCIAUiSZx7SeFuqLS7nCtfEwgHM7zfhJQTx2AUf6qW0P0TAiEAh-UwgffnlRaz5cjYeGirABt2FTcgyiuLuv-NOpdJQf8"
+                              }
+
+packedNonSelfAttestedTest = genericCredentialTest "Packed non-self attested test" packedNonSelfAttestedKeyCredential
 
 genericCredentialTest :: String -> TestPublicKeyCredential -> TestTree
 genericCredentialTest name TestPublicKeyCredential{..} = testCaseSteps name $ \step -> do


### PR DESCRIPTION
https://www.w3.org/TR/2020/CR-webauthn-2-20201222/

this PR also adds tests for 'packed' formats (self and non-self attested). I also have tests for FIDOU2F and TPM in separate branches. When (and if) this gets merged I will create the other PRs to cater for that. 

https://github.com/kubek2k/webauthn/commit/876fd4dcf348ff0173cb749ecf66e4cd32be4dfc
and 
https://github.com/kubek2k/webauthn/commit/ceb7b6340436d457754e6bc732a70b46b8f45520

This is an outcome of my review with current state of the spec that you can find here:
https://github.com/fumieval/webauthn/compare/master...kubek2k:webauthn-spec-review-22-12-2020