### PR TITLE
Rework

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,38 +1,37 @@
 name: Haskell CI
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: ['*']
+on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-        ghc: ["8.8", "8.10"]
-        cabal: ["3.2"]
-
+        ghc: [ '9.2.1' ]
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.4'
 
-    - name: Cache cabal stuff
-      uses: actions/cache@v2
+    - name: cabal Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
       with:
-        path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}
-
-    - run: cabal update 
-
-    - name: Build & Test webauthn
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
       run: |
-        cabal build
-        cabal test
-        cabal haddock
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks all
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all
+    - name: Run tests
+      run: cabal test --enable-tests --enable-benchmarks all

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,58 @@ packages:
   ./wai-middleware-webauthn/
   ./wai-middleware-webauthn/demo/
 
+allow-newer:
+  wuss:base,
+  cereal:base,
+  basement:base,
+  websockets:bytestring,
+  wuss:bytestring,
+  aeson:base,
+  hsc2hs:base,
+
+source-repository-package
+  type: git
+  location: git@github.com:brandon-leapyear/haskell-src-meta.git
+  tag: 3f521f9
+  subdir: haskell-src-meta
+
+source-repository-package
+  type: git
+  location: git@github.com:fpco/streaming-commons.git
+  tag: ac8c695
+
+source-repository-package
+  type: git
+  location: https://github.com/ekmett/lens.git
+  tag: 211c2fbbea8fb64a7f3f72d709a95f0e2e3995b8
+
+source-repository-package
+  type: git
+  location: https://github.com/kazu-yamamoto/iproute
+  tag: 1acc17af9cf770fdbabf55fcb7a949939efe0af4
+
+source-repository-package
+  type: git
+  location: https://github.com/TomMD/foundation
+  tag: 0bb195e1fea06d144dafc5af9a0ff79af0a5f4a0
+  subdir: basement
+
+source-repository-package
+  type: git
+  location: https://github.com/bos/aeson
+  tag: 3dff21c7a0fec9a50f7ffd950a257368c7a6d25a
+
+source-repository-package
+  type: git
+  location: https://github.com/fumieval/hs-memory
+  tag: 7d385cecad6d496ab0dc079237ed133b5de43b2d
+
+source-repository-package
+  type: git
+  location: https://github.com/josephcsible/cryptonite
+  tag: 3b081e3ad027b0550fc87f171dffecbb20dedafe
+
+source-repository-package
+  type: git
+  location: https://github.com/fumieval/prelude-dot
+  tag: a3de0ad10b2d6588daaeeb3cb5d88f89447bc652

--- a/cabal.project
+++ b/cabal.project
@@ -14,13 +14,13 @@ allow-newer:
 
 source-repository-package
   type: git
-  location: git@github.com:brandon-leapyear/haskell-src-meta.git
+  location: https://github.com/brandon-leapyear/haskell-src-meta.git
   tag: 3f521f9
   subdir: haskell-src-meta
 
 source-repository-package
   type: git
-  location: git@github.com:fpco/streaming-commons.git
+  location: https://github.com/fpco/streaming-commons.git
   tag: ac8c695
 
 source-repository-package
@@ -53,8 +53,3 @@ source-repository-package
   type: git
   location: https://github.com/josephcsible/cryptonite
   tag: 3b081e3ad027b0550fc87f171dffecbb20dedafe
-
-source-repository-package
-  type: git
-  location: https://github.com/fumieval/prelude-dot
-  tag: a3de0ad10b2d6588daaeeb3cb5d88f89447bc652

--- a/src/WebAuthn/AndroidSafetyNet.hs
+++ b/src/WebAuthn/AndroidSafetyNet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-} 
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 module WebAuthn.AndroidSafetyNet (
   decode,
@@ -31,12 +31,13 @@ import Data.Char (ord)
 import Data.Bifunctor (first)
 import WebAuthn.Signature (verifyX509Sig)
 import Control.Error.Util (hoistEither, failWith)
+import Time.Types (DateTime)
 
 decode :: CBOR.Term -> CBOR.Decoder s StmtSafetyNet
 decode (CBOR.TMap xs) = do
   let m = Map.fromList xs
   let CBOR.TBytes response = fromMaybe (CBOR.TString "response") (Map.lookup (CBOR.TString "response") m)
-  case B.split (fromIntegral . ord $ '.') response of 
+  case B.split (fromIntegral . ord $ '.') response of
     (h : p : s : _) -> StmtSafetyNet (Base64ByteString h) (Base64ByteString p) (Base64URL.decodeLenient s) <$> getCertificateChain h
     _ -> fail "decodeSafetyNet: response was not a JWT"
 decode _ = fail "decodeSafetyNet: expected a Map"
@@ -53,23 +54,24 @@ getCertificateChain h = do
           Left e -> fail ("Certificate chain decode failed: " <> show e)
           Right cc -> pure cc
 
-verify :: MonadIO m => X509.CertificateStore 
-  -> StmtSafetyNet 
+verify :: MonadIO m => X509.CertificateStore
+  -> StmtSafetyNet
   -> B.ByteString
   -> Digest SHA256
+  -> Maybe DateTime
   -> ExceptT VerificationFailure m ()
-verify cs sf authDataRaw clientDataHash = do
+verify cs sf authDataRaw clientDataHash maybeNow = do
   verifyJWS
   let dat = authDataRaw <> BA.convert clientDataHash
   as <- extractAndroidSafetyNet
   let nonceCheck = Base64.encode (BA.convert (hash dat :: Digest SHA256))
   if nonceCheck /= BL.toStrict (BL.pack (nonce as)) then throwE NonceCheckFailure else pure ()
   where
-    extractAndroidSafetyNet = ExceptT $ pure $ first JSONDecodeError 
+    extractAndroidSafetyNet = ExceptT $ pure $ first JSONDecodeError
       $ J.eitherDecode (BL.fromStrict . Base64URL.decodeLenient . unBase64ByteString $ payload sf)
     verifyJWS = do
       let dat = unBase64ByteString (header sf) <> "." <> unBase64ByteString (payload sf)
-      res <- liftIO $ X509.validateDefault cs (X509.exceptionValidationCache []) ("attest.android.com", "") (certificates sf)
+      res <- liftIO $ validateCert cs (X509.exceptionValidationCache []) ("attest.android.com", "") (certificates sf)
       case res of
         [] -> pure ()
         es -> throwE (MalformedX509Certificate (pack $ show es))
@@ -77,9 +79,10 @@ verify cs sf authDataRaw clientDataHash = do
       let pub = X509.certPubKey $ X509.getCertificate cert
       hoistEither $ verifyX509Sig rs256 pub dat (signature sf) "AndroidSafetyNet"
     signCert (X509.CertificateChain cschain) = headMay cschain
+    validateCert = X509.validate X509.HashSHA256 X509.defaultHooks (X509.defaultChecks { X509.checkAtTime = maybeNow})
 
 rs256 :: X509.SignatureALG
-rs256 = X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_RSA  
+rs256 = X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_RSA
 
 headMay :: [a] -> Maybe a
 headMay [] = Nothing

--- a/src/WebAuthn/Base.hs
+++ b/src/WebAuthn/Base.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TypeFamilies #-}
 module WebAuthn.Base
   ( Base64ByteString(..)
   , Challenge(..)
   , AAGUID(..)
   , CredentialId(..)
   , CredentialPublicKey(..)
+  , Required
+  , Complete
+  , Incomplete
   ) where
 
 import Codec.Serialise qualified as CBOR
@@ -18,6 +22,7 @@ import Data.ByteString.Char8 qualified as B8
 import Data.Hashable
 import Data.String
 import Data.Text.Encoding ( decodeUtf8, encodeUtf8 )
+import Data.Kind (Type)
 import GHC.Generics (Generic)
 
 -- | A wrapper of 'ByteString' where its contents is Base64-encoded in JSON
@@ -63,3 +68,10 @@ newtype CredentialId = CredentialId { unCredentialId :: ByteString }
 newtype CredentialPublicKey = CredentialPublicKey { unCredentialPublicKey :: ByteString }
   deriving (Eq, Hashable, CBOR.Serialise)
   deriving (FromJSON, ToJSON, Show, IsString) via Base64ByteString
+
+data Complete
+data Incomplete
+
+type family Required a b :: Type where
+  Required Incomplete _ = ()
+  Required Complete t = t

--- a/src/WebAuthn/Base.hs
+++ b/src/WebAuthn/Base.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DerivingVia #-}
+module WebAuthn.Base
+  ( Base64ByteString(..)
+  , Challenge(..)
+  , AAGUID(..)
+  , CredentialId(..)
+  , CredentialPublicKey(..)
+  ) where
+
+import Codec.Serialise qualified as CBOR
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteArray (ByteArrayAccess)
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Base64.URL qualified as Base64
+import Data.ByteString.Char8 qualified as B8
+import Data.Hashable
+import Data.String
+import Data.Text.Encoding ( decodeUtf8, encodeUtf8 )
+import GHC.Generics (Generic)
+
+-- | A wrapper of 'ByteString' where its contents is Base64-encoded in JSON
+newtype Base64ByteString = Base64ByteString { unBase64ByteString :: ByteString } deriving (Generic, Eq, ByteArrayAccess)
+
+instance Show Base64ByteString where
+  show = show . Base64.encode . unBase64ByteString
+
+-- | Expects Base64
+instance IsString Base64ByteString where
+  fromString = Base64ByteString . Base64.decodeLenient . B8.pack
+
+instance ToJSON Base64ByteString where
+  toJSON (Base64ByteString bs) = String $ decodeUtf8 $ Base64.encode bs
+
+instance FromJSON Base64ByteString where
+  parseJSON = withText "Base64ByteString" $ \v -> do
+    let eth = Base64.decode (encodeUtf8 v)
+    case eth of
+      Left err -> typeMismatch ("Base64: " <> err) (String v)
+      Right str -> pure (Base64ByteString str)
+
+-- | 13.1. Cryptographic Challenges
+newtype Challenge = Challenge { rawChallenge :: ByteString }
+  deriving (Eq, Ord, Generic, Hashable, CBOR.Serialise)
+  deriving (FromJSON, ToJSON, Show, IsString) via Base64ByteString
+
+-- | AAGUID of the authenticator
+newtype AAGUID = AAGUID { unAAGUID :: ByteString } deriving (Show, Eq)
+
+instance FromJSON AAGUID where
+  parseJSON v = AAGUID . Base16.decodeLenient . encodeUtf8 <$> parseJSON v
+
+instance ToJSON AAGUID where
+  toJSON = toJSON . decodeUtf8 . Base16.encode . unAAGUID
+
+-- | A probabilistically-unique byte sequence identifying a public key credential source and its authentication assertions.
+newtype CredentialId = CredentialId { unCredentialId :: ByteString }
+  deriving (Eq, Generic, Hashable, CBOR.Serialise)
+  deriving (FromJSON, ToJSON, Show, IsString) via Base64ByteString
+
+-- | credential public key encoded in COSE_Key format
+newtype CredentialPublicKey = CredentialPublicKey { unCredentialPublicKey :: ByteString }
+  deriving (Eq, Hashable, CBOR.Serialise)
+  deriving (FromJSON, ToJSON, Show, IsString) via Base64ByteString

--- a/src/WebAuthn/FIDOU2F.hs
+++ b/src/WebAuthn/FIDOU2F.hs
@@ -31,8 +31,8 @@ verify :: Stmt
   -> Digest SHA256
   -> Either VerificationFailure ()
 verify (Stmt cert sig) AuthenticatorData{..} clientDataHash = do
-  AttestedCredentialData{..} <- maybe (Left MalformedAuthenticatorData) pure attestedCredentialData
-  m <- either (Left . CBORDecodeError "verifyFIDOU2F") pure
+  AttestedCredentialData{..} <- maybe (Left $ MalformedAuthenticatorData "FIDOU2F") pure attestedCredentialData
+  m <- either (Left . CBORDecodeError "FIDOU2F.verify") pure
     $ CBOR.deserialiseOrFail $ BL.fromStrict $ unCredentialPublicKey credentialPublicKey
   pubU2F <- maybe (Left MalformedPublicKey) pure $ do
       CBOR.TBytes x <- Map.lookup (-2 :: Int) m

--- a/src/WebAuthn/Packed.hs
+++ b/src/WebAuthn/Packed.hs
@@ -9,6 +9,7 @@ import Data.ASN1.Encoding (decodeASN1)
 import Data.Maybe (isJust)
 import qualified Data.ASN1.OID as OID (OID, getObjectID)
 import Data.List (find)
+import Data.String
 import Control.Monad (unless)
 import Crypto.Hash
 import qualified Data.ByteString as BS
@@ -54,8 +55,8 @@ verify (Stmt algo sig cert) mAdPubKey AuthenticatorData{..} adRaw clientDataHash
         verifyX509Sig (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pub dat sig "Packed"
         certMeetsCriteria x509Cert
     Nothing -> do
-      adPubKey <- maybe (Left MalformedAuthenticatorData) return mAdPubKey
-      unless (hasMatchingAlg adPubKey algo) $ Left MalformedAuthenticatorData
+      adPubKey <- maybe (Left $ MalformedAuthenticatorData "Packed public key") return mAdPubKey
+      unless (hasMatchingAlg adPubKey algo) $ Left $ MalformedAuthenticatorData $ "Packed:" <> fromString (show algo)
       verifySig adPubKey sig dat
     where
         certMeetsCriteria :: X509.Certificate -> Either VerificationFailure ()

--- a/src/WebAuthn/Types.hs
+++ b/src/WebAuthn/Types.hs
@@ -31,7 +31,6 @@ module WebAuthn.Types (
   , StmtSafetyNet(..)
   , JWTHeader(..)
   , Base64ByteString(..)
-  , PublicKeyCredentialRequestOptions(..)
   , PublicKeyCredentialDescriptor(..)
   , AuthenticatorTransport(..)
   , PublicKeyCredentialType(..)
@@ -253,19 +252,6 @@ data UserVerification = Required | Preferred | Discouraged deriving (Show, Eq, G
 instance ToJSON UserVerification where
   toEncoding = genericToEncoding defaultOptions { sumEncoding = UntaggedValue, constructorTagModifier = fmap toLower }
   toJSON = genericToJSON defaultOptions { sumEncoding = UntaggedValue, constructorTagModifier = fmap toLower }
-
-data PublicKeyCredentialRequestOptions =  PublicKeyCredentialRequestOptions
-  { challenge :: Challenge
-  , timeout :: Maybe Integer
-  , rpId :: Maybe Text
-  , allowCredentials ::Maybe (NonEmpty PublicKeyCredentialDescriptor)
-  , userVerification :: Maybe UserVerification
-  -- extensions omitted as support is minimal https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions/extensions
-  } deriving (Eq, Show, Generic)
-
-instance ToJSON PublicKeyCredentialRequestOptions where
-  toEncoding = genericToEncoding defaultOptions { omitNothingFields = True}
-  toJSON = genericToJSON defaultOptions { omitNothingFields = True}
 
 data PubKeyCredAlg = ES256 -- -7
   | RS256 -- (-257)

--- a/src/WebAuthn/Types.hs
+++ b/src/WebAuthn/Types.hs
@@ -217,7 +217,7 @@ data VerificationFailure
   | UnsupportedAttestationFormat Text
   | UnsupportedAlgorithm Int
   | MalformedPublicKey
-  | MalformedAuthenticatorData
+  | MalformedAuthenticatorData Text
   | MalformedX509Certificate Text
   | MalformedSignature
   | SignatureFailure String
@@ -377,7 +377,7 @@ defaultCredentialCreationOptions
   -> CredentialCreationOptions
 defaultCredentialCreationOptions relyingParty challenge user = CredentialCreationOptions
   { timeout = Nothing
-  , credParams = ES256 NE.:| []
+  , credParams = NE.fromList [ES256, RS256]
   , attestation = Nothing
   , extensions = Nothing
   , authenticatorSelection = Nothing

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -122,9 +124,10 @@ genericCredentialTest name TestPublicKeyCredential{..} now = testCaseSteps name 
   Just certificateStore <- readCertificateStore "test/cacert.pem"
   eth <- RegisterCredentialArgs
       { options = defaultCredentialCreationOptions
-        (defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn")
-        challenge
-        (User (Base64ByteString "id") "display name")
+        { rp = defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn"
+        , challenge
+        , user = User (Base64ByteString "id") "display name"
+        }
       , tokenBindingID = Nothing
       , ..
       }.run

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE RecordWildCards #-}
 import WebAuthn
     ( registerCredential,
-      verify )
+      VerifyArgs(..),
+      verify,
+    )
 import Test.Tasty ( defaultMain, testGroup, TestTree )
 import Test.Tasty.HUnit (assertEqual,  assertBool, testCaseSteps )
 import Data.String.Interpolate ()
@@ -126,7 +128,16 @@ genericCredentialTest name TestPublicKeyCredential{..} time = testCaseSteps name
   assertBool (show eth) (isRight eth)
   let Right cdata = eth
   step "Verification check..."
-  let eth = verify getChallenge defRp Nothing False getClientDataJSON getAuthenticatorData getSignature cdata.credentialPublicKey
+  let eth = verify VerifyArgs
+        { challenge = getChallenge
+        , relyingParty = defRp
+        , tokenBindingID = Nothing
+        , requireVerification = False
+        , clientDataJSON = getClientDataJSON
+        , authenticatorData = getAuthenticatorData
+        , signature = getSignature
+        , credentialPublicKey = cdata.credentialPublicKey
+        }
   assertBool (show eth) (isRight eth)
 
 registrationTest :: TestTree

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -27,11 +27,11 @@ import WebAuthn.Types
       AuthenticatorTransport(BLE),
       User(User),
       AttestedCredentialData(..),
-      RelyingParty,
       Origin(Origin),
       Challenge(Challenge),
       Base64ByteString(Base64ByteString),
-      defaultRelyingParty, PublicKeyCredentialType (PublicKey) )
+      PublicKeyCredentialType (PublicKey),
+      PublicKeyCredentialRpEntity )
 import Data.Aeson.QQ.Simple ( aesonQQ )
 import Data.List.NonEmpty ( NonEmpty((:|)) )
 import Data.Aeson.Encoding (value)
@@ -56,8 +56,8 @@ androidTests = testGroup "WebAuthn Tests"
 androidCredentialTest :: TestTree
 androidCredentialTest = genericCredentialTest "Android test" androidPublicKeyCredential (Just $ timeConvert (Date 2020 June 1))
 
-defRp :: RelyingParty
-defRp = defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn"
+defRp :: PublicKeyCredentialRpEntity
+defRp = "psteniusubi.github.io"
 
 decodePanic :: FromJSON a => ByteString -> a
 decodePanic s = either error Prelude.id (A.eitherDecode (BL.fromStrict s))
@@ -124,7 +124,7 @@ genericCredentialTest name TestPublicKeyCredential{..} now = testCaseSteps name 
   Just certificateStore <- readCertificateStore "test/cacert.pem"
   eth <- RegisterCredentialArgs
       { options = defaultCredentialCreationOptions
-        { rp = defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn"
+        { rp = defRp
         , challenge
         , user = User (Base64ByteString "id") "display name"
         }
@@ -150,7 +150,7 @@ registrationTest :: TestTree
 registrationTest = testCaseSteps "Credentials Test" $ \step -> do
   step "Credential creation"
   let pkcco = CredentialCreationOptions
-        { rp = defaultRelyingParty (Origin "https" "webauthn.biz" Nothing) "webauthn"
+        { rp = defRp
         , challenge = Challenge "12343434"
         , user = User (Base64ByteString "id") "display name"
         , pubKeyCredParams = ES256 :| []

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -26,10 +26,11 @@ import WebAuthn.Types
       Origin(Origin),
       Challenge(Challenge),
       Base64ByteString(Base64ByteString),
-      defaultRelyingParty )
+      defaultRelyingParty, PublicKeyCredentialType (PublicKey) )
 import Data.Aeson.QQ.Simple ( aesonQQ )
 import Data.List.NonEmpty ( NonEmpty((:|)) )
 import Data.Aeson.Encoding (value)
+import Data.Hourglass (DateTime, timeConvert, Date (Date), Month (June))
 
 main :: IO ()
 main = defaultMain tests
@@ -38,25 +39,25 @@ tests :: TestTree
 tests = testGroup "Tests" [androidTests]
 
 androidTests :: TestTree
-androidTests = testGroup "WebAuthn Tests" 
+androidTests = testGroup "WebAuthn Tests"
   [
     -- See: https://github.com/fumieval/webauthn/issues/9
-    -- androidCredentialTest
-    packedSelfAttestedTest
+    androidCredentialTest
+    , packedSelfAttestedTest
     , packedNonSelfAttestedTest
     , fidoU2FAttestedTest
   ]
 
 androidCredentialTest :: TestTree
-androidCredentialTest = genericCredentialTest "Android test" androidPublicKeyCredential
+androidCredentialTest = genericCredentialTest "Android test" androidPublicKeyCredential (Just $ timeConvert (Date 2020 June 1))
 
 defRp :: RelyingParty
-defRp = defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing)
+defRp = defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn"
 
 decodePanic :: FromJSON a => ByteString -> a
 decodePanic s = either error Prelude.id (A.eitherDecode (BL.fromStrict s))
 
-data TestPublicKeyCredential = TestPublicKeyCredential 
+data TestPublicKeyCredential = TestPublicKeyCredential
   { clientDataJSON :: ByteString
   , attestationObject :: ByteString
   , challenge :: Challenge
@@ -66,7 +67,7 @@ data TestPublicKeyCredential = TestPublicKeyCredential
   , getSignature :: ByteString
   }
 
-androidPublicKeyCredential = TestPublicKeyCredential 
+androidPublicKeyCredential = TestPublicKeyCredential
   { clientDataJSON = androidClientDataJSON
   , attestationObject = androidAttestationObject
   , challenge = androidChallenge
@@ -76,7 +77,7 @@ androidPublicKeyCredential = TestPublicKeyCredential
   , getSignature = androidGetSignature
   }
 
-packedSelfAttestedKeyCredential = TestPublicKeyCredential 
+packedSelfAttestedKeyCredential = TestPublicKeyCredential
   { clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSkhxcVRQWF9oQkw1bHlDZE9DQzRMNTVzcm9LbXFMX0RDemlOeWx6MXF5dyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
   , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEYwRAIgaAVCWvaUJo0NBq_c1yr7R9jXN-G8MqqIOVhswsTX4K0CIFZul9oOTdWwDx4WAb3cgPTTjWzXSSxcjseS33OVqhgWaGF1dGhEYXRhWNUs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUVgAZ6yrc4AAjW8xgpkiwsl8fBVAwBRAft9ACeHPR6QCu6Clp5otBmdIyMGV6w1emT--vpR_JpIKPJdIkNLOjzoLqd-z_j3vKvLCB4pQAwccqPF56HKs4h8DsrEuG0mMx5jJz_9ndh1pQECAyYgASFYIFgD8QsPYGMaq49F7-JWJowfVaxeiFzJUXp2k8nvrRpUIlggyGWqdGOBLZgO61mPMEncHjTmBxFPWzqKbUlBvT1fhRg"
   , challenge = "JHqqTPX_hBL5lyCdOCC4L55sroKmqL_DCziNylz1qyw="
@@ -86,9 +87,9 @@ packedSelfAttestedKeyCredential = TestPublicKeyCredential
   , getSignature = BS.decodeLenient "MEYCIQDteZqnEublzIw5AgnOzu5sd7b387GitIHbjNSXFFoFxgIhAP4IFIiyweG__D3VOBSnvneuK794RuGoUNasXhQNe0gk"
   }
 
-packedSelfAttestedTest = genericCredentialTest "Packed self attested test" packedSelfAttestedKeyCredential
+packedSelfAttestedTest = genericCredentialTest "Packed self attested test" packedSelfAttestedKeyCredential Nothing
 
-packedNonSelfAttestedKeyCredential = TestPublicKeyCredential 
+packedNonSelfAttestedKeyCredential = TestPublicKeyCredential
   { clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTU1jVUFkWkJ2STRENktNYldjZW44bTNNRElCRWVWQWxkalBwcjYzZWFJbyIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
   , attestationObject = BS.decodeLenient "o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIge9MVIqCg80CbXoD2m6Hu4J6EKztfia76dtOoAeDUejQCIQCQwLbwVYoiYsAcOf8iigzbixDBiUAYJpUCIoa-XXvuYmN4NWOBWQLBMIICvTCCAaWgAwIBAgIEGKxGwDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNDEzOTQzNDg4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeeo7LHxJcBBiIwzSP-tg5SkxcdSD8QC-hZ1rD4OXAwG1Rs3Ubs_K4-PzD4Hp7WK9Jo1MHr03s7y-kqjCrutOOqNsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCBSAwIQYLKwYBBAGC5RwBAQQEEgQQy2lIHo_3QDmT7AonKaFUqDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCXnQOX2GD4LuFdMRx5brr7Ivqn4ITZurTGG7tX8-a0wYpIN7hcPE7b5IND9Nal2bHO2orh_tSRKSFzBY5e4cvda9rAdVfGoOjTaCW6FZ5_ta2M2vgEhoz5Do8fiuoXwBa1XCp61JfIlPtx11PXm5pIS2w3bXI7mY0uHUMGvxAzta74zKXLslaLaSQibSKjWKt9h-SsXy4JGqcVefOlaQlJfXL1Tga6wcO0QTu6Xq-Uw7ZPNPnrpBrLauKDd202RlN4SP7ohL3d9bG6V5hUz_3OusNEBZUn5W3VmPj1ZnFavkMB3RkRMOa58MZAORJT4imAPzrvJ0vtv94_y71C6tZ5aGF1dGhEYXRhWMQs15PPoLQYy78OqFIihgfZ6XszPU2wpBAXdmr2u4x1UUUAAAAuy2lIHo_3QDmT7AonKaFUqABAPjPqie67O5ZBLiBEWi1uF8ueqxifIu5txG8qQ82HiribGY2F99HPJ_ZTgRbEZCVySxy0Xbd-tiUzyEwmJQsiNqUBAgMmIAEhWCAiZN75DKsRFIWYKExiHA_ZpKIJGbRlL2JYE6iw9x1OGSJYILwa9HpPBuZ4S4BfT4wigrSzs_V6m47z0A1wsetLUwl1"
   , challenge = Challenge (BS.decodeLenient "MMcUAdZBvI4D6KMbWcen8m3MDIBEeVAldjPpr63eaIo")
@@ -98,9 +99,9 @@ packedNonSelfAttestedKeyCredential = TestPublicKeyCredential
   , getSignature = BS.decodeLenient "MEUCIAUiSZx7SeFuqLS7nCtfEwgHM7zfhJQTx2AUf6qW0P0TAiEAh-UwgffnlRaz5cjYeGirABt2FTcgyiuLuv-NOpdJQf8"
   }
 
-packedNonSelfAttestedTest = genericCredentialTest "Packed non-self attested test" packedNonSelfAttestedKeyCredential
+packedNonSelfAttestedTest = genericCredentialTest "Packed non-self attested test" packedNonSelfAttestedKeyCredential Nothing
 
-fidoU2FAttestedKeyCredential = TestPublicKeyCredential 
+fidoU2FAttestedKeyCredential = TestPublicKeyCredential
   { clientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVHF5dWZTNmJCam5obk5sT09BcWN3X2tfcW9DZVhrdy1VbkQ2X1QxTEZ6WSIsIm9yaWdpbiI6Imh0dHBzOi8vcHN0ZW5pdXN1YmkuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
   , attestationObject = BS.decodeLenient "o2NmbXRoZmlkby11MmZnYXR0U3RtdKJjc2lnWEcwRQIgLalQZ_wPQbHRQJWvkSb9pMwykJTIglVyO9tQqJBdWeACIQDW9PpXo-7gcl8f8MOvcQZ2a-BV0NDtsKysznwF17hTmmN4NWOBWQHiMIIB3jCCAYCgAwIBAgIBATANBgkqhkiG9w0BAQsFADBgMQswCQYDVQQGEwJVUzERMA8GA1UECgwIQ2hyb21pdW0xIjAgBgNVBAsMGUF1dGhlbnRpY2F0b3IgQXR0ZXN0YXRpb24xGjAYBgNVBAMMEUJhdGNoIENlcnRpZmljYXRlMB4XDTE3MDcxNDAyNDAwMFoXDTQxMDExMDE1MDgwNVowYDELMAkGA1UEBhMCVVMxETAPBgNVBAoMCENocm9taXVtMSIwIAYDVQQLDBlBdXRoZW50aWNhdG9yIEF0dGVzdGF0aW9uMRowGAYDVQQDDBFCYXRjaCBDZXJ0aWZpY2F0ZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1hfmXJUI5kvMVnOsgqZ5naPBRGaCwljEY__99Y39L6Pmw3i1PXlcSk3_tBme3Xhi8jq68CA7S4kRugVpmU4QGjKDAmMBMGCysGAQQBguUcAgEBBAQDAgUgMA8GA1UdEwEB_wQFMAMBAQAwDQYJKoZIhvcNAQELBQADSQAwRgIhALzf9AI7ncZCUGONkRJg1j0giitNVEtql2-DNLkUcAKNAiEAl2FZKfyv8wP6gq8a15Zwvb0IuqhbW6Oa3ChynC2bc-JoYXV0aERhdGFYpCzXk8-gtBjLvw6oUiKGB9npezM9TbCkEBd2ava7jHVRQQAAAAAAAAAAAAAAAAAAAAAAAAAAACAeEV8OookaEAnZsZ6sTBQd34n7FG-UChiAg_h4Wds73qUBAgMmIAEhWCAxZCF_UplKr9yfSrWtQbCeHBu8kmi9wJpIldWlT3fFMiJYIMHLS8tIUgpZgxb706EC_Hx6P6qoeBZHKVhOtc80uLbz"
   , challenge = Challenge (BS.decodeLenient "TqyufS6bBjnhnNlOOAqcw_k_qoCeXkw-UnD6_T1LFzY")
@@ -110,22 +111,43 @@ fidoU2FAttestedKeyCredential = TestPublicKeyCredential
   , getSignature = BS.decodeLenient "MEYCIQDhsVWAb0QLCdfLpjfWSv1jDQXTlL-eR0jqxpY09UsO7QIhALG5c5ORMNAyRR2R7NcOWDLHKKmV9KZM5S1miiVhYmZ5"
   }
 
-fidoU2FAttestedTest = genericCredentialTest "FIDOU2F test" packedNonSelfAttestedKeyCredential
+fidoU2FAttestedTest = genericCredentialTest "FIDOU2F test" packedNonSelfAttestedKeyCredential Nothing
 
-genericCredentialTest :: String -> TestPublicKeyCredential -> TestTree
-genericCredentialTest name TestPublicKeyCredential{..} = testCaseSteps name $ \step -> do
+genericCredentialTest :: String -> TestPublicKeyCredential -> Maybe DateTime -> TestTree
+genericCredentialTest name TestPublicKeyCredential{..} time = testCaseSteps name $ \step -> do
   step "Registeration check..."
   Just store <- readCertificateStore "test/cacert.pem"
   eth <- registerCredential store (defaultCredentialCreationOptions
-      (defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing))
+      (defaultRelyingParty (Origin "https" "psteniusubi.github.io" Nothing) "webauthn")
       challenge
-      (User (Base64ByteString "id") Nothing Nothing)) clientDataJSON attestationObject
+      (User (Base64ByteString "id") "name" "display name")) clientDataJSON attestationObject
+      time
   assertBool (show eth) (isRight eth)
   let Right cdata = eth
   step "Verification check..."
   let eth = verify getChallenge defRp Nothing False getClientDataJSON getAuthenticatorData getSignature (credentialPublicKey cdata)
-  assertBool (show eth) (isRight eth)  
+  assertBool (show eth) (isRight eth)
 
+registrationTest :: TestTree
+registrationTest = testCaseSteps "Credentials Test" $ \step -> do
+  step "Credential creation"
+  let pkcco = CredentialCreationOptions (defaultRelyingParty (Origin "https" "webauthn.biz" Nothing) "webauthn") (Challenge "12343434") (User (Base64ByteString "id") "name" "display name")
+        (ES256 :| []) Nothing Nothing Nothing Nothing (Just (PublicKeyCredentialDescriptor PublicKey (Base64ByteString "1234") (Just (BLE :| []))  :| [])) Nothing
+  let ref = [aesonQQ| {
+    "rp":{"id":"webauthn.biz", "name": "webauthn"},
+    "challenge":"MTIzNDM0MzQ=",
+    "user":{"id":"id", "name": "name", "displayName":"display name"},
+    "pubKeyCredParams":[
+      {
+        "type":"public-key",
+        "alg":-7
+      }],
+    "excludeCredentials":[
+      {"type":"public-key", "id": "MTIzNA==", "transports":["ble"]}
+      ]
+    }
+  |]
+  assertEqual "TOJSON not equal" ref (toJSON pkcco)
 
 androidClientDataJSON :: ByteString
 androidClientDataJSON = BS.decodeLenient "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiWkIyQVJraDZ3RVBoZkdjSFBRWWpWNXNidmxoa3liVlN1ZFQ4Q0VzNTBsNCIsIm9yaWdpbiI6Imh0dHBzOlwvXC9wc3Rlbml1c3ViaS5naXRodWIuaW8iLCJhbmRyb2lkUGFja2FnZU5hbWUiOiJjb20uYW5kcm9pZC5jaHJvbWUifQ"

--- a/wai-middleware-webauthn/README.md
+++ b/wai-middleware-webauthn/README.md
@@ -4,6 +4,17 @@ wai-middleware-webauthn
 This is a WAI middleware which introduces a simple authentication mechanism
 based on [Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API) (WebAuthn).
 
+Demo
+----
+
+```
+cabal run demo
+```
+
+Starts a demo application. Open https://localhost:8080/ and click the Register button once you filled the display name.
+If successful, it prints the credential in the top section. Copy the credential to `config.yaml` and restart the server.
+If the credential is stored in the authenticator and `config.yaml` correctly, you should be able to `Login with WebAuthn` using the key of the credential in `config.yaml`.
+
 Configuration
 ----
 

--- a/wai-middleware-webauthn/demo/Main.hs
+++ b/wai-middleware-webauthn/demo/Main.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import WebAuthn.Types (Origin(..))
 import qualified Network.Wai.Middleware.WebAuthn as WebAuthn
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
@@ -20,7 +22,9 @@ main = do
   path <- getDataFileName "index.html"
   pathCert <- getDataFileName "certificate.pem"
   pathKey <- getDataFileName "key.pem"
-  runTLS (tlsSettings pathCert pathKey) (setPort 8080 defaultSettings) { settingsHTTP2Enabled = False }
+  putStrLn $ "Listening on " <> show config.origin
+  let cfg = maybe id setPort config.origin.port defaultSettings
+  runTLS (tlsSettings pathCert pathKey) cfg { settingsHTTP2Enabled = False }
     $ mid $ \req sendResp -> case pathInfo req of
       [] -> sendResp $ responseFile status200 [] path Nothing
       ["api"] -> case WebAuthn.requestIdentifier req of

--- a/wai-middleware-webauthn/demo/config.yaml
+++ b/wai-middleware-webauthn/demo/config.yaml
@@ -2,8 +2,9 @@ origin: "https://localhost:8080"
 endpoint: "webauthn"
 handler:
   fumieval:
-  - aaguid: "00000000000000000000000000000000"
-    credentialId: vcr_XnaBZx6AH3nuDSsmRFS2ZgEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    credentialPublicKey: pQECAyYgASFYIJFR_dt_GWkw5Ldvu2FW9rIjULYzOWpYG_IAmOuqxRbHIlggd8EFrDs8DOrouUYtzqRWPO5Mo84cJf1dWkbhaUmECaM=
+  - aaguid: '6028b017b1d44c02b4b3afcdafc96bb2'
+    credentialId: qvckt-DKXr-GUBbO59dMSKG-yvoa2Yc_61FCSeOBcac=
+    credentialPublicKey: pAEDAzkBACBZAQDlqjCMWJds42iAaL725dkbk6Tre3Ut70aSvRbf_R4-zw1VkDGdZv-Es2ZmPOlhflFXenmiGVzPGmrS1PyX6391pBDG0x_pTWcUQmdrJhPavBKx4YV7y5X3eeBsa5EnNhRrDUAqpim4QPy6RKsRU-b71TzYjL3Lhz5bou4mt2NFLZGPNA9yVYS2nETM_yMKqLvWNXrKJksofYRUAVyobEvJjmimcjYNgyNhdebi14p9bU355s8FiZFzjrwMZeeRlURBTTmN8uXJUmGIlq0oH0jY0zG5uQvZQc6CDvYLAmN1EVhU3tmysdqqRxjrVxBd8LM67vnwIDN5cmdtrD_UXUB1IUMBAAE=
 
 timeout: 86400
+certStore: "demo/cacert.pem"

--- a/wai-middleware-webauthn/demo/demo.cabal
+++ b/wai-middleware-webauthn/demo/demo.cabal
@@ -30,6 +30,7 @@ executable demo
     , bytestring
     , http-types
     , wai
+    , webauthn
     , wai-middleware-webauthn
     , warp
     , warp-tls

--- a/wai-middleware-webauthn/demo/demo.cabal
+++ b/wai-middleware-webauthn/demo/demo.cabal
@@ -17,7 +17,7 @@ maintainer:    fumiexcel@gmail.com
 -- copyright:
 -- category:
 -- extra-source-files:  CHANGELOG.md
-data-files:    index.html
+data-files:    index.html, cacert.pem, lib.js
 
 executable demo
   main-is:          Main.hs

--- a/wai-middleware-webauthn/demo/index.html
+++ b/wai-middleware-webauthn/demo/index.html
@@ -80,7 +80,7 @@
           };
         auth.register(user).then(result => {
           var div = document.createElement("section");
-          div.innerHTML = "Add the following pair to config.yaml: <pre><code>"
+          div.innerHTML = "Add the following pair to config.yaml and restart: <pre><code>"
             + user.displayName + ":"
             + "\n- aaguid: '" + result.aaguid
             + "'\n  credentialId: " + result.credentialId

--- a/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
+++ b/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
@@ -50,7 +50,7 @@ type StaticKeys = HM.HashMap Identifier [AttestedCredentialData]
 staticKeys :: StaticKeys -> Handler
 staticKeys authorisedKeys = Handler
   { findCredentials = \ident -> pure
-    $ maybe [] id
+    $ maybe [] Prelude.id
     $ HM.lookup ident authorisedKeys
   , findPublicKey = \cid -> pure $ HM.lookup cid authorisedMap
   , registerKey = \_ _ -> pure ()
@@ -98,9 +98,9 @@ mkMiddleware :: Config Handler -> IO Middleware
 mkMiddleware Config{..} = do
   vTokens <- newIORef HM.empty
   libJSPath <- getDataFileName "lib.js"
-  cspath <- (getDataFileName "cacert.pem")
+  cspath <- getDataFileName "cacert.pem"
   Just cs <- X509.readCertificateStore cspath
-  let theRelyingParty = W.defaultRelyingParty origin
+  let theRelyingParty = W.defaultRelyingParty origin "Display Name"
 
   _ <- forkIO $ forever $ do
       now <- getMonotonicTime

--- a/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
+++ b/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
@@ -111,7 +111,7 @@ mkMiddleware Config{..} = do
 
   return $ \app req sendResp -> case pathInfo req of
     x : xs | x == endpoint -> case xs of
-      ["lib.js"] -> sendResp $ responseFile status200 headers libJSPath Nothing -- TODO data-files
+      ["lib.js"] -> sendResp $ responseFile status200 headers libJSPath Nothing
       ["challenge"] -> do
         challenge <- generateChallenge 16
         sendResp $ responseJSON challenge

--- a/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
+++ b/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
@@ -103,7 +103,6 @@ mkMiddleware Config{..} = do
   certificateStore <- X509.readCertificateStore certStore >>= \case
     Nothing -> fail $ "Failed to obtain certification store from " <> certStore
     Just a -> pure a
-  let theRelyingParty = W.defaultRelyingParty origin "Display Name"
 
   _ <- forkIO $ forever $ do
       now <- getMonotonicTime
@@ -126,7 +125,7 @@ mkMiddleware Config{..} = do
           defaultRegisterCredentialArgs
             { certificateStore
             , options = defaultCredentialCreationOptions
-              { rp = theRelyingParty
+              { rp = originToRelyingParty origin
               , challenge
               , user
               }
@@ -145,7 +144,7 @@ mkMiddleware Config{..} = do
         findPublicKey handler cid >>= \case
           Just (name, pub) -> case verify VerifyArgs
             { challenge = challenge
-            , relyingParty = theRelyingParty
+            , relyingParty = originToRelyingParty origin
             , tokenBindingID = Nothing
             , requireVerification = False
             , clientDataJSON = cdj

--- a/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
+++ b/wai-middleware-webauthn/src/Network/Wai/Middleware/WebAuthn.hs
@@ -121,13 +121,19 @@ mkMiddleware Config{..} = do
       ["register"] -> do
         body <- lazyRequestBody req
         let (user, clientDataJSON, attestationObject, challenge) = CBOR.deserialise body
+
         rg <- W.registerCredential
           defaultRegisterCredentialArgs
             { certificateStore
-            , options = defaultCredentialCreationOptions theRelyingParty challenge user
+            , options = defaultCredentialCreationOptions
+              { rp = theRelyingParty
+              , challenge
+              , user
+              }
             , clientDataJSON
             , attestationObject
             }
+
         case rg of
           Left e -> sendResp $ responseBuilder status403 headers $ fromString $ show e
           Right cd -> do

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -14,13 +14,13 @@ tested-with:    GHC == 8.8.4
 
 common base-common
   build-depends:
-    , aeson             >=1.5  && <1.6
-    , base              >=4.13 && <4.15
+    , aeson             ^>=2.0
+    , base              >=4.13 && <4.17
     , base64-bytestring >=1.2  && <1.3
     , bytestring        >=0.10 && <0.12
     , errors            >=2.3  && <2.4
     , x509-store        >=1.6  && <1.7
-
+    , hourglass         ^>= 0.2
   default-language:   Haskell2010
 
 library
@@ -43,7 +43,7 @@ library
     , cereal            >=0.5  && <0.6
     , deriving-aeson    ^>= 0.2
     , containers        >=0.6  && <0.7
-    , cryptonite        >=0.28 && <0.29
+    , cryptonite        >=0.29 && <0.30
     , hashable          >=1.3  && <1.4
     , memory            >=0.14 && <1.16
     , serialise         >=0.2  && <0.3
@@ -52,7 +52,8 @@ library
     , x509              >=1.7  && <1.8
     , x509-validation   >=1.6  && <1.7
 
-  ghc-options:        -Wall
+  ghc-options:        -Wall -Wcompat
+  default-extensions: ImportQualifiedPost
 
 test-suite test-webauthn
   import:             base-common

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -29,6 +29,7 @@ library
   exposed-modules:
     WebAuthn
     WebAuthn.AndroidSafetyNet
+    WebAuthn.Base
     WebAuthn.FIDOU2F
     WebAuthn.Packed
     WebAuthn.Signature
@@ -53,7 +54,12 @@ library
     , x509-validation   >=1.6  && <1.7
 
   ghc-options:        -Wall -Wcompat
-  default-extensions: ImportQualifiedPost
+  default-extensions:
+    ImportQualifiedPost
+    GeneralisedNewtypeDeriving
+    DeriveGeneric
+    RecordWildCards
+    ScopedTypeVariables
 
 test-suite test-webauthn
   import:             base-common

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -9,13 +9,12 @@ license-file:  LICENSE
 author:        Fumiaki Kinoshita, Sumit Raja <sumitraja@gmail.com>
 maintainer:    fumiexcel@gmail.com
 category:      Web
-tested-with:    GHC == 8.8.4
-              , GHC == 8.10.4
+tested-with:   GHC == 9.2.1
 
 common base-common
   build-depends:
     , aeson             ^>=2.0
-    , base              >=4.13 && <4.17
+    , base              >=4.16 && <4.17
     , base64-bytestring >=1.2  && <1.3
     , bytestring        >=0.10 && <0.12
     , errors            >=2.3  && <2.4


### PR DESCRIPTION
* Redesigned datatypes, making use of NoFieldSelectors and DuplicateRecordFields
* `registerCredential` and `verify` now take dedicated data types `RegisterCredentialArgs` and `VerifyArgs` respectively
* Added CBOR `Serialise` instance for `AttestationObject`
* Simplified `User` according to the spec
* Replaced `RelyingParty` with `PublicKeyCredentialRpEntity` which contains the RP ID only
* Fixed #16 